### PR TITLE
Update SDK Version & SecureConnect/Register/Deregister API usage

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -21,6 +21,6 @@ target 'SidewalkSampleApp' do
   # Comment the next line if you don't want to use dynamic frameworks
   use_frameworks!
 
-  pod 'SidewalkSDK', '~> 1.1.0'
+  pod 'SidewalkSDK', '~> 1.2.0'
 
 end

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # amazon-sidewalk-ios-samples
 
-## Building the Sidewalk Sample App
+## Building the Amazon Sidewalk Sample App
 1. Please use the latest version of Xcode and Cocoapods.
 2. Run `pod install` and open the SidewalkSampleApp.xcworkspace project file with Xcode.
 3. Highlight SidewalkSampleApp, select Signing & Capabilities, and use your team (or create a free personal one) & any available unique bundle identifier. You should probably follow your team's naming convention.
@@ -12,14 +12,14 @@
     a. Use your favorite way of importing [OpenSSL](https://www.openssl.org/).
 6. Run the app on an iPhone. The simulator will not have bluetooth capabilities.
 
-## Testing with the Sidewalk Sample App
-1. The Sidewalk Sample App provides scanning, registration, deregistration, and secure connect capabilities.
+## Testing with the Amazon Sidewalk Sample App
+1. The Amazon Sidewalk Sample App provides scanning, registration, deregistration, and secure connect capabilities.
 2. Scanning will start automatically.
-3. Click on Menu -> Login to authenticate, use your Amazon test account. NOTE: The Amazon account is required to be linked with a Ring account for Sidewalk functionalities.
-4. Long press a found device in the UNREGISTERED DEVICES section, and click register to go through the Sidewalk registration process.
+3. Click on Menu -> Login to authenticate, use your Amazon test account.
+4. Long press a found device in the UNREGISTERED DEVICES section, and click register to go through the Amazon Sidewalk registration process.
 5. A spinner indicates the registration progress. There will be a pop up with an error or success once the process completes. 
 6. Long press a found device in any section, and click Secure Connect to initiate a secure connection. Upon success, this will take you to the secure connection page. You can also register with a secure connection (preferred if you already have one), which is showcased here.
-7. Menu -> Deregister allows you to deregister a device. Input the Sidewalk ID which was returned after registration. Sidewalk ID is also the endpoint ID of registered devices.
+7. Menu -> Deregister allows you to deregister a device with the Sidewalk Manufacturing Serial Number(`SMSN`) of the device.
 8. Logs may be viewed in Xcode Debugger as well as the Device Console. In Xcode, go to Window → Devices and Simulators → Click on your phone in right panel → Open Console. Search for "process:SidewalkSampleApp".
 
 ## Security

--- a/SidewalkSampleApp.xcodeproj/project.pbxproj
+++ b/SidewalkSampleApp.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		399C16E42863293E00881B34 /* SidewalkSampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 399C16D42863293E00881B34 /* SidewalkSampleApp.swift */; };
 		4802D62A2942C63500E5AB53 /* OpenSSL.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4802D6292942C63400E5AB53 /* OpenSSL.xcframework */; };
 		4802D62B2942C63500E5AB53 /* OpenSSL.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4802D6292942C63400E5AB53 /* OpenSSL.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		48731F6A29EFAF7000A1A820 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48731F6929EFAF6F00A1A820 /* Utils.swift */; };
 		48AEB09A299CC65E00AEA082 /* LoginWithAmazon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48AEB099299CC65D00AEA082 /* LoginWithAmazon.framework */; };
 		FD333D7E2994CE4C0098E064 /* CoverageTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD333D7D2994CE4C0098E064 /* CoverageTestView.swift */; };
 		FD333D802994CE6E0098E064 /* CoverageTestViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD333D7F2994CE6E0098E064 /* CoverageTestViewModel.swift */; };
@@ -66,6 +67,7 @@
 		399C16D42863293E00881B34 /* SidewalkSampleApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SidewalkSampleApp.swift; sourceTree = "<group>"; };
 		399C16D52863293E00881B34 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4802D6292942C63400E5AB53 /* OpenSSL.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = OpenSSL.xcframework; path = Frameworks/OpenSSL.xcframework; sourceTree = "<group>"; };
+		48731F6929EFAF6F00A1A820 /* Utils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		48AEB099299CC65D00AEA082 /* LoginWithAmazon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = LoginWithAmazon.framework; path = Frameworks/LoginWithAmazon.framework; sourceTree = "<group>"; };
 		FD333D7D2994CE4C0098E064 /* CoverageTestView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoverageTestView.swift; sourceTree = "<group>"; };
 		FD333D7F2994CE6E0098E064 /* CoverageTestViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoverageTestViewModel.swift; sourceTree = "<group>"; };
@@ -117,6 +119,7 @@
 		399C16C22863293E00881B34 /* SidewalkSampleApp */ = {
 			isa = PBXGroup;
 			children = (
+				48731F6929EFAF6F00A1A820 /* Utils.swift */,
 				399C16C82863293E00881B34 /* AmazonAuthService.swift */,
 				399C16CA2863293E00881B34 /* SimpleLogger.swift */,
 				399C16CD2863293E00881B34 /* SidewalkEnvironment.swift */,
@@ -241,6 +244,7 @@
 				399C16DF2863293E00881B34 /* ScanView.swift in Sources */,
 				399C16D72863293E00881B34 /* ConnectionViewModel.swift in Sources */,
 				399C16D92863293E00881B34 /* DeregisterViewModel.swift in Sources */,
+				48731F6A29EFAF7000A1A820 /* Utils.swift in Sources */,
 				399C16E32863293E00881B34 /* LoadingView.swift in Sources */,
 				399C16DA2863293E00881B34 /* AmazonAuthService.swift in Sources */,
 				399C16E42863293E00881B34 /* SidewalkSampleApp.swift in Sources */,

--- a/SidewalkSampleApp/AmazonAuthService.swift
+++ b/SidewalkSampleApp/AmazonAuthService.swift
@@ -37,7 +37,7 @@ final class AmazonAuthService {
 
     @Published var authState: AuthState = .none
 
-    /// Updates the internal auth status using a authroization request
+    /// Updates the internal auth status using a authroization request.
     func updateAuthState() {
         let request: AMZNAuthorizeRequest = AMZNAuthorizeRequest()
         request.interactiveStrategy = .never
@@ -53,7 +53,7 @@ final class AmazonAuthService {
         lwaAuthorize(request: request)
     }
 
-    /// Logs the user out
+    /// Logs the user out.
     func logout() {
         AMZNAuthorizationManager.shared().signOut { error in
             if let error = error {

--- a/SidewalkSampleApp/Utils.swift
+++ b/SidewalkSampleApp/Utils.swift
@@ -1,0 +1,47 @@
+//
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify,
+// merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import SidewalkSDK
+
+extension RegistrationDetail {
+    var message: String {
+        switch self {
+        case .alreadyRegistered:
+            return "Device already registered"
+        case .registrationSucceeded:
+            return "Device registered successfully"
+        @unknown default:
+            assertionFailure("Warning: Unhandled case in RegistrationDetail")
+            return "Device registration succeeded"
+        }
+    }
+}
+
+struct AlertModel {
+    let alertTitle: String
+    let alertText: String
+    let buttonText: String
+    let buttonAction: (() -> Void)?
+
+    init(alertTitle: String, alertText: String, buttonText: String, buttonAction: (() -> Void)? = nil) {
+        self.alertTitle = alertTitle
+        self.alertText = alertText
+        self.buttonText = buttonText
+        self.buttonAction = buttonAction
+    }
+}

--- a/SidewalkSampleApp/View/DeregisterView.swift
+++ b/SidewalkSampleApp/View/DeregisterView.swift
@@ -44,7 +44,7 @@ struct DeregisterView<Content>: View where Content: View {
                             EmptyView()
                         case .input:
                             InputView(state: $viewModel.state,
-                                      sidewalkId: $viewModel.sidewalkId,
+                                      smsn: $viewModel.smsn,
                                       deregisterAction: viewModel.deregister)
                         case .loading:
                             LoadingView()
@@ -68,13 +68,13 @@ struct DeregisterView<Content>: View where Content: View {
 
     private struct InputView: View {
         @Binding var state: DeregisterViewModel.State
-        @Binding var sidewalkId: String
+        @Binding var smsn: String
         let deregisterAction: () -> Void
 
         var body: some View {
             VStack {
                 Text("Deregister").font(.title)
-                TextField("Sidewalk ID", text: $sidewalkId).textFieldStyle(.roundedBorder)
+                TextField("SMSN Value", text: $smsn).textFieldStyle(.roundedBorder)
                 Divider()
                 HStack {
                     Spacer()

--- a/SidewalkSampleApp/View/ScanView.swift
+++ b/SidewalkSampleApp/View/ScanView.swift
@@ -143,7 +143,7 @@ struct SidewalkDeviceRow: View {
     var body: some View {
         HStack {
             Text(device.name ?? "Unknown")
-            Text(device.endpointID)
+            Text(device.truncatedSmsn)
             Text("\(device.rssi)" )
         }.contextMenu {
             // Allow registration when the device is in Out-of-box experience mode

--- a/SidewalkSampleApp/ViewModel/CoverageTestViewModel.swift
+++ b/SidewalkSampleApp/ViewModel/CoverageTestViewModel.swift
@@ -104,7 +104,7 @@ final class CoverageTestViewModel: ObservableObject {
             return
         }
         showSpinner = true
-        // secureConnect returns a Sidewalk Cancellable, which must be held in memory. If released, it will automatically cancel the operation
+        // secureConnect returns a SidewalkCancellable, which must be held in memory. If released, it will automatically cancel the operation.
         let operation = sidewalk.secureConnect(device: device) { [weak self] result in
             DispatchQueue.main.async {
                 guard let strongSelf = self else { return }

--- a/SidewalkSampleApp/ViewModel/DeregisterViewModel.swift
+++ b/SidewalkSampleApp/ViewModel/DeregisterViewModel.swift
@@ -29,7 +29,7 @@ final class DeregisterViewModel: ObservableObject {
     }
 
     let sidewalk: Sidewalk
-    @Published var sidewalkId: String = ""
+    @Published var smsn: String = ""
     @Published var state: State
     var operation: SidewalkCancellable? = nil
 
@@ -38,19 +38,17 @@ final class DeregisterViewModel: ObservableObject {
         state = .hidden
     }
 
-    /// Deregister a Sidewalk device via a Sidewalk ID.
+    /// Deregister a Sidewalk device via a SMSN.
     func deregister() {
-        // The sidewalk ID is expected to be provided by the consuming application.
-        operation = sidewalk.deregister(sidewalkID: sidewalkId, factoryReset: true) { result in
-            DispatchQueue.main.async { [weak self] in
-                guard let self = self else {
-                    return
-                }
+        // The smsn is expected to be provided by the consuming application.
+        operation = sidewalk.deregisterDevice(smsn: smsn, factoryReset: true) { [weak self] result in
+            DispatchQueue.main.async {
+                guard let strongSelf = self else { return }
                 switch result {
                 case .success:
-                    self.state = .confirmation(.success("Deregistration for \(self.sidewalkId) succeeded"))
+                    strongSelf.state = .confirmation(.success("Deregistration for \(strongSelf.smsn) succeeded"))
                 case .failure(let error):
-                    self.state = .confirmation(.failure(error))
+                    strongSelf.state = .confirmation(.failure(error))
                 }
             }
         }


### PR DESCRIPTION
Changes:
1. Bump SidewalkSDK version to 1.2.0 in Podfile
2. Replace `secureConnect` with `secureConnectDevice`, `register` with `registerDevice`, `deregister` with `deregisterDevice` to simplify device management with `smsn` value.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
